### PR TITLE
Watch files starting with dot by default

### DIFF
--- a/lib/cli/watch-run.js
+++ b/lib/cli/watch-run.js
@@ -30,7 +30,10 @@ const collectFiles = require('./collect-files');
  */
 module.exports = (mocha, {watchFiles, watchIgnore}, fileCollectParams) => {
   if (!watchFiles) {
-    watchFiles = fileCollectParams.extension.map(ext => `**/*.${ext}`);
+    watchFiles = fileCollectParams.extension.reduce(
+      (watchFiles, ext) => watchFiles.concat([`**/*.${ext}`, `**/.*.${ext}`]),
+      []
+    );
   }
 
   const watcher = chokidar.watch(watchFiles, {

--- a/test/integration/options/watch.spec.js
+++ b/test/integration/options/watch.spec.js
@@ -137,6 +137,24 @@ describe('--watch', function() {
       });
     });
 
+    it('reruns test when file starting with . and matching --extension is changed', function() {
+      const testFile = path.join(this.tempDir, 'test.js');
+      copyFixture('__default__', testFile);
+
+      const watchedFile = path.join(this.tempDir, '.file.xyz');
+      touchFile(watchedFile);
+
+      return runMochaWatch(
+        [testFile, '--extension', 'xyz,js'],
+        this.tempDir,
+        () => {
+          touchFile(watchedFile);
+        }
+      ).then(results => {
+        expect(results, 'to have length', 2);
+      });
+    });
+
     it('ignores files in "node_modules" and ".git" by default', function() {
       const testFile = path.join(this.tempDir, 'test.js');
       copyFixture('__default__', testFile);


### PR DESCRIPTION
_Work in progress based on #3980_

With this change Mocha will watch files starting with a dot by default. For example `mocha --watch` will rerun tests if the files `foo/.bar.js` is changed. Similarly, `mocha --watch --extension jsx` will rerun tests if the file `foo/.bar.jsx` is changed.